### PR TITLE
Expose internal pointer to AImage

### DIFF
--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -310,7 +310,7 @@ pub struct Image {
 pub type CropRect = ffi::AImageCropRect;
 
 impl Image {
-    fn as_ptr(&self) -> *mut ffi::AImage {
+    pub fn as_ptr(&self) -> *mut ffi::AImage {
         self.inner.as_ptr()
     }
 

--- a/ndk/src/media/image_reader.rs
+++ b/ndk/src/media/image_reader.rs
@@ -89,7 +89,7 @@ impl ImageReader {
         }
     }
 
-    fn as_ptr(&self) -> *mut ffi::AImageReader {
+    pub fn as_ptr(&self) -> *mut ffi::AImageReader {
         self.inner.as_ptr()
     }
 


### PR DESCRIPTION
- needed for doing some direct operation on AImage ptr (maybe unsafe)
- but anyways i think the library need not enforce AImage ptr to be hidden